### PR TITLE
Delay backdrop change until popupDelay finishes

### DIFF
--- a/app/tour-controller.js
+++ b/app/tour-controller.js
@@ -265,9 +265,17 @@
 
             return handleEvent(step.config('onShow')).then(function () {
 
-                if (step.config('backdrop')) {
-                    uiTourBackdrop.createForElement(step.element, step.config('preventScrolling'), step.config('fixed'));
+                if (!step.config('backdrop')) {
+                    return;
                 }
+
+                var delay = step.config('popupDelay');
+                return $q(function (resolve) {
+                    $timeout(function () {
+                        uiTourBackdrop.createForElement(step.element, step.config('preventScrolling'), step.config('fixed'));
+                        resolve();
+                    }, delay);
+                })
 
             }).then(function () {
 


### PR DESCRIPTION
In the case of animation between frames, the backdrop will instantly appear, which might bind to the elements while they are animating.  By waiting until the popupDelay has finished to create the backdrop, this can be avoided.

TODO:  Maybe hide the previous backdrop?