### PR TITLE
Step destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ scope of the uiTour directive, and can be required as `TourController` in direct
 | goTo()       | Hides the current step and jumps to the provided one. <br> **Parameters:** _step_ Can be step object, step ID string, or step index <br> **Returns:** _Promise_ Resolved when provided step is shown, rejects if no step provided or found. |
 | getStatus()  | Returns the current status of the tour based on TourStatus enum. <br> **Parameters:** \<none\> <br> **Returns:** TourStatus (ON, OFF, PAUSED, WAITING). Usage example: after tour starts: `tour.getStatus() === tour.Status.ON; //true`     |
 | createStep() | Adds a step via a step configuration object. <br> **Parameters:** _step_ - a step config object: must contain an `element` (jQLite object) or `selector` (string) attribute. `selector` is resolved the first time a step is shown.         |
+| destroyStep()| Remove a step from the tour as well as remove its popup from the DOM as well. <br> **Parameters:** _step_ - a step returned by `createStep()`.                                                                                              |
 | reposition() | Forces the active step popover and backdrop (if visible) to reposition around the step target. This is useful when the size of the target changes dynamically after the step is activated.                                                  |
 
 ### `createStep()` Example

--- a/app/tour-controller.js
+++ b/app/tour-controller.js
@@ -589,9 +589,8 @@ export default function uiTourController($timeout, $q, $filter, $document, TourC
         var index = stepList.indexOf(step);
 
         if (index !== -1) {
-          const stepItem = stepList[index];
-          TourStepService.destroyPopup(stepItem);
-          self.removeStep(step);
+            TourStepService.destroyPopup(stepList[index]);
+            self.removeStep(step);
         }
     };
 

--- a/app/tour-controller.js
+++ b/app/tour-controller.js
@@ -580,6 +580,22 @@ export default function uiTourController($timeout, $q, $filter, $document, TourC
     };
 
     /**
+    * Destroy a step with destroying the created popup as well
+    *
+    * @protected
+    * @param step
+    */
+    self.destroyStep = function (step) {
+        var index = stepList.indexOf(step);
+
+        if (index !== -1) {
+          const stepItem = stepList[index];
+          TourStepService.destroyPopup(stepItem);
+          self.removeStep(step);
+        }
+    };
+
+    /**
      * returns a copy of the current step (copied to avoid breaking internal functions)
      *
      * @returns {step}

--- a/app/tour-step-service.js
+++ b/app/tour-step-service.js
@@ -56,7 +56,16 @@ export default function (Tether, $compile, $document, $templateCache, $rootScope
         }
     }
 
-    /**
+  /**
+   * Destroy a step's popover
+   *
+   * @param {{}} step - Step options
+   */
+    service.destroyPopup = function (step) {
+        step.popup.remove();
+    };
+
+  /**
      * Initializes a step from a config object
      *
      * @param {{}} step - Step options

--- a/dist/angular-ui-tour.js
+++ b/dist/angular-ui-tour.js
@@ -3275,12 +3275,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 
 	    /**
-	     * Initializes a step from a config object
+	     * Destroy a step's popover
 	     *
 	     * @param {{}} step - Step options
-	     * @param {{}} tour - The tour to which the step belongs
-	     * @returns {*} configured step
 	     */
+	    service.destroyPopup = function (step) {
+	        step.popup.remove();
+	    };
+
+	    /**
+	       * Initializes a step from a config object
+	       *
+	       * @param {{}} step - Step options
+	       * @param {{}} tour - The tour to which the step belongs
+	       * @returns {*} configured step
+	       */
 	    service.createStep = function (step, tour) {
 	        if (!step.element && !step.elementId && !step.selector) {
 	            throw {
@@ -3995,6 +4004,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 
 	        return step;
+	    };
+
+	    /**
+	    * Destroy a step with destroying the created popup as well
+	    *
+	    * @protected
+	    * @param step
+	    */
+	    self.destroyStep = function (step) {
+	        var index = stepList.indexOf(step);
+
+	        if (index !== -1) {
+	            TourStepService.destroyPopup(stepList[index]);
+	            self.removeStep(step);
+	        }
 	    };
 
 	    /**


### PR DESCRIPTION
When i created a step using `createStep`, it's going to automatically create the popup as well and insert it to the DOM. However I had no service to properly destroy/remove this `step` (returned by `createStep`), so I created a service.

@benmarch  Let me know your thoughts if I need to structure my code on a different way or if something is missing. Thanks, and thanks for this library!