### PR TITLE
'!important' is not necessary

### DIFF
--- a/app/tour-step-service.js
+++ b/app/tour-step-service.js
@@ -91,7 +91,7 @@ export default function (Tether, $compile, $document, $templateCache, $rootScope
         if (step.tether) {
             step.tether.disable();
         }
-        step.popup[0].style.setProperty('display', 'none', 'important');
+        step.popup[0].style.setProperty('display', 'none');
     }
 
     /**


### PR DESCRIPTION
The '!important' causes problems on IE11 and removiing it does not affect Chrome and FireFox