### PR TITLE
angular-bind-html-compile dependency to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "angular-scroll": "1.0.2",
     "hone": "1.1.0",
     "tether": "1.4.0",
-    "angular-bind-html-compile": "https://github.com/incuna/angular-bind-html-compile.git#1.4.1"
+    "angular-bind-html-compile": "1.4.1"
   },
   "devDependencies": {
     "angular-mocks": "1.6.6",


### PR DESCRIPTION
Changed the angular-bind-html-compile dependency from a git URL to a npm package version to make it work on build servers without access to github.